### PR TITLE
Readme: fix serious typo in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $enabler->activate(true);
 ### Options
 - `$enabler->activate(true)` - force to Debug Mode turn on,
 - `$enabler->activate(false)` - force to Debug Mode turn off,
-- `$enabler->deactivate(false)` - reset back to automatically detection by environment.
+- `$enabler->deactivate()` - reset back to automatically detection by environment.
 
 ### Using with Nette
 Debug Mode Enabler (unlike Debug Mode Detector) can be simply served through DI Container with configuration in `config.neon`:


### PR DESCRIPTION
## Wrong Readme
> ### Options
> - `$enabler->activate(true)` - force to Debug Mode turn on,
> - `$enabler->activate(false)` - force to Debug Mode turn off,
> - `$enabler->deactivate(false)` - reset back to automatically detection by environment.

Method `\Redbitcz\DebugMode\Enabler::deactivate()` has `bool` argument, but that's bug, there is no arguments.

## RIght Readme
> ### Options
> - `$enabler->activate(true)` - force to Debug Mode turn on,
> - `$enabler->activate(false)` - force to Debug Mode turn off,
> - `$enabler->deactivate()` - reset back to automatically detection by environment.

