### PR TITLE
SignUrl: Fix request build from global environment

### DIFF
--- a/src/Plugin/SignedUrl.php
+++ b/src/Plugin/SignedUrl.php
@@ -283,16 +283,24 @@ class SignedUrl implements Plugin
     {
         $urlSegments = [];
         $urlSegments['scheme'] = !empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'off') ? 'https' : 'http';
-        $urlSegments['host'] = strtolower($_SERVER['HTTP_HOST'] ?? '');
+        if (isset($_SERVER['HTTP_HOST'])) {
+            $urlSegments['host'] = strtolower($_SERVER['HTTP_HOST']);
+        }
 
         $requestUrl = $_SERVER['REQUEST_URI'] ?? '/';
         $requestUrl = preg_replace('#^\w++://[^/]++#', '', $requestUrl);
         $tmp = explode('?', $requestUrl, 2);
         $urlSegments['path'] = $tmp[0];
-        $urlSegments['query'] = ($tmp[1] ?? '');
+        if (isset($tmp[1])) {
+            $urlSegments['query'] = $tmp[1];
+        }
 
-        $urlSegments['user'] = ($_SERVER['PHP_AUTH_USER'] ?? '');
-        $urlSegments['pass'] = ($_SERVER['PHP_AUTH_PW'] ?? '');
+        if (isset($_SERVER['PHP_AUTH_USER'])) {
+            $urlSegments['user'] = $_SERVER['PHP_AUTH_USER'];
+        }
+        if (isset($_SERVER['PHP_AUTH_PW'])) {
+            $urlSegments['pass'] = $_SERVER['PHP_AUTH_PW'];
+        }
 
         return $this->buildUrl($urlSegments);
     }

--- a/src/Plugin/SignedUrl.php
+++ b/src/Plugin/SignedUrl.php
@@ -200,9 +200,14 @@ class SignedUrl implements Plugin
         }
 
         $parsedUrl = $this->normalizeUrl($parsedUrl);
-        $signedUrl = $this->buildUrl(
-            ['query' => $tokenOffset > 0 ? substr($query, 0, $tokenOffset) : null] + $parsedUrl
-        );
+        if ($tokenOffset > 0) {
+            $parsedUrl['query'] = substr($query, 0, $tokenOffset);
+        } else {
+            unset($parsedUrl['query']);
+            /** @var ParsedUrl $parsedUrl (bypass PhpStan bug) */
+        }
+
+        $signedUrl = $this->buildUrl($parsedUrl);
 
         if ($signedUrl !== $allowedUrl) {
             throw new SignedUrlVerificationException('URL doesn\'t match signed URL');

--- a/src/Plugin/SignedUrl.php
+++ b/src/Plugin/SignedUrl.php
@@ -174,7 +174,7 @@ class SignedUrl implements Plugin
         // Note: Not parsed by parse_str() to prevent broke URL (repeated arguments like `?same_arg=1&same_arg=2`)
         $query = $parsedUrl['query'] ?? '';
         if (preg_match(
-                '/(?<token_key>[?&]' . self::URL_QUERY_TOKEN_KEY . '=)(?<token>[^&]+)(?:$|(?<remaining>&.*$))/D',
+                '/(?<token_key>(?:^|&|^&)' . self::URL_QUERY_TOKEN_KEY . '=)(?<token>[^&]+)(?:$|(?<remaining>&.*$))/D',
                 $query,
                 $matches,
                 PREG_OFFSET_CAPTURE
@@ -200,7 +200,9 @@ class SignedUrl implements Plugin
         }
 
         $parsedUrl = $this->normalizeUrl($parsedUrl);
-        $signedUrl = $this->buildUrl(['query' => substr($query, 0, $tokenOffset)] + $parsedUrl);
+        $signedUrl = $this->buildUrl(
+            ['query' => $tokenOffset > 0 ? substr($query, 0, $tokenOffset) : null] + $parsedUrl
+        );
 
         if ($signedUrl !== $allowedUrl) {
             throw new SignedUrlVerificationException('URL doesn\'t match signed URL');

--- a/tests/Plugin/SignUrlTest.php
+++ b/tests/Plugin/SignUrlTest.php
@@ -94,6 +94,24 @@ class SignUrlTest extends \Tester\TestCase
     {
         $audience = 'test.' . __FUNCTION__;
         $timestamp = 1600000000;
+        $url = 'https://host.tld/path';
+
+        $plugin = new SignedUrl(self::KEY_HS256, 'HS256', $audience);
+        $plugin->setTimestamp($timestamp);
+        $tokenUrl = $plugin->signUrl($url, 1600000600);
+
+        $plugin = new SignedUrl(self::KEY_HS256, 'HS256', $audience);
+        $plugin->setTimestamp($timestamp);
+        JWT::$timestamp = $timestamp;
+        $parsed = $plugin->verifyUrl($tokenUrl);
+        $expected = [['get'], 0, 1, 1600000600];
+        Assert::equal($expected, $parsed);
+    }
+
+    public function testVerifyUrlQuery(): void
+    {
+        $audience = 'test.' . __FUNCTION__;
+        $timestamp = 1600000000;
         $url = 'https://host.tld/path?query=value';
 
         $plugin = new SignedUrl(self::KEY_HS256, 'HS256', $audience);


### PR DESCRIPTION
Fix invalid URL create from global environment

Before: `http://:@localhost:8080/?_debug=eyJ0eXAiOiJKV1QiLCJ…`

After: `http://localhost:8080/?_debug=eyJ0eXAiOiJKV1QiLCJ…`