### PR TITLE
Enabler: Fix filtered values saved as list

### DIFF
--- a/src/Enabler.php
+++ b/src/Enabler.php
@@ -213,7 +213,7 @@ class Enabler
             }
         );
 
-        $this->writeStorage($list);
+        $this->writeStorage(array_values($list));
     }
 
     // TOKEN UTILS -----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Token is saved as Object instead of Array type, because `array_filter()` can corrupt regular list format.

See more about PHP list vs Array at: https://www.php.net/manual/en/function.array-is-list.php